### PR TITLE
Fix Chinese TTS

### DIFF
--- a/DuolingoReverseTreeEnhancer.user.js
+++ b/DuolingoReverseTreeEnhancer.user.js
@@ -124,6 +124,7 @@ var lastSaidSlow = false;
 
 function googleTTSLang(targetLang) {
     if (targetLang == "dn") { return "nl"; }
+    if (targetLang == "zs") { return "zh"; }
     return targetLang;    
 }
 


### PR DESCRIPTION
Duolingo uses 'zs' as code for Chinese. Google TTS uses 'zh'.

This patch adds a new match in "googleTTSLang()" to fix that problem
