### PR TITLE
fix for "hide text" option (orange text still appearing)

### DIFF
--- a/DuolingoTreeEnhancer.user.js
+++ b/DuolingoTreeEnhancer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Duolingo Tree Enhancer
 // @namespace    https://github.com/camiloaa/duolingotreeenhancer
-// @version      1.0.9
+// @version      1.0.10
 // @description  Enhance Duolingo by customizing difficulty and providing extra functionality. Based on Guillaume Brunerie's ReverseTreeEnhancer
 // @author       Camilo Arboleda
 // @match        https://www.duolingo.com/*

--- a/DuolingoTreeEnhancer.user.js
+++ b/DuolingoTreeEnhancer.user.js
@@ -102,7 +102,9 @@ var css_hiding_title = toStyleElem('._1Zqmf:' + css_hiding_style);
 
 /* Elements to hide: Translate questions & judge options */
 var css_hiding_target = toStyleElem('._1SfYc:' + css_hiding_style 
-        + '._31nDg:' + css_hiding_style);
+        + '._31nDg:' + css_hiding_style
+        + '._3_AmQ:' + css_hiding_style
+        + '_1SfYc _1qCW5:' + css_hiding_style);
 
 var css_hiding_pics = toStyleElem('._1o8rO { opacity: 0; } \n'
         + '.eSlsq { opacity: 0; } \n');


### PR DESCRIPTION
This patch fixes an issue were new words would still be visible in orange even if the "hide text" option was enable.