### PR TITLE
function to mute Duo speaking

### DIFF
--- a/DuolingoTreeEnhancer.user.js
+++ b/DuolingoTreeEnhancer.user.js
@@ -328,6 +328,11 @@ var audio = [];
 var utter = [];
 var synth;
 
+// mute web audio
+function muteDuo() {
+	window.Howler._muted=true;
+}
+
 // Play an audio element.
 function playURL(url, lang, speaker_button) {
 


### PR DESCRIPTION
Should mute everything what Duo is playing including the 'bing'.
Seems to work like 'tab mute' on your browser.