### PR TITLE
Make punctuation visible in listening exercises

### DIFF
--- a/DuolingoTreeEnhancer.user.js
+++ b/DuolingoTreeEnhancer.user.js
@@ -246,6 +246,10 @@ css_style_hide_text = `{parent} {child}:not(:hover){
     flex-basis:100%
 }
 
+{child} span[data-test="hint-token"] {
+    color: #3c3c3c;
+}
+
 {child} ._1bkpY:not(:hover) {
     color: inherit;
 }


### PR DESCRIPTION
It is often unclear if listening exercises are questions or statements. This can be troublesome when you're practicing a language where the only difference between a question and a statement is a question mark.

The two sentences "Вы говорите по-немецки?" and "Вы говорите по-немецки." only differs in punctuation. The first one asks "Do you speak German?" while the other states "You are speaking German.", and without any clues through the TTS, the user is often forced to guess or remember this exact sentence. I suggest not hiding punctuation, in order to make it easier to tell questions and statements apart.